### PR TITLE
Make it work on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Setup a webserver and point it at the Umbraco.Belle directory. then browse to wh
 
 To run on *windows*, setup IIS or IIS express to serve the umbraco.belle folder. If you have web matrix installed, you can right-click the folder and open it in web matrix to run it its built-in webserver.
 
-To run on *osx*, open term in the umbraco.belle folder and run:
+To run on *OS X*, open Terminal in the umbraco.belle folder and run:
 	
 	python -m SimpleHTTPServer 8080
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To run on *windows*, setup IIS or IIS express to serve the umbraco.belle folder.
 
 To run on *osx*, open term in the umbraco.belle folder and run:
 	
-	python -m SimpleHttpServer 8080
+	python -m SimpleHTTPServer 8080
 
 This will have the site on http://localhost:8080/belle
 


### PR DESCRIPTION
I couldn't get the `SimpleHTTPServer` command working, until I realised it was a case-sensitivity thing... so here's a simple change for other _copy-pasters_ like me :-)
